### PR TITLE
実況チャンネルを名称からsidで判定するように変更

### DIFF
--- a/modules/Controllers/JikkyoController.php
+++ b/modules/Controllers/JikkyoController.php
@@ -49,9 +49,9 @@ class JikkyoController {
         
                     // 実況 ID を取得
                     if (isset($ch[$settings[$stream]['channel']])){
-                        $nicojikkyo_id = $instance->getNicoJikkyoID($ch[$settings[$stream]['channel']]);
+                        $nicojikkyo_id = $instance->getNicoJikkyoID($sid[$settings[$stream]['channel']]);
                     } else if ($ch[intval($settings[$stream]['channel']).'_1']){
-                        $nicojikkyo_id = $instance->getNicoJikkyoID($ch[intval($settings[$stream]['channel']).'_1']);
+                        $nicojikkyo_id = $instance->getNicoJikkyoID($sid[intval($settings[$stream]['channel']).'_1']);
                     } else {
                         $nicojikkyo_id = null;
                     }

--- a/modules/Models/Jikkyo.php
+++ b/modules/Models/Jikkyo.php
@@ -132,22 +132,25 @@ class Jikkyo {
 
         // 配列を回す
         foreach ($channel_table as $channel_record) {
-	
-	    if(intval($channel_sid) > 333){ // 地上波の時
-	        $jikkyo_sid = hexdec(mb_substr($channel_record['ServiceID'],2));
-	    }else { // 地上波以外
-	        $jikkyo_sid = $channel_record['ServiceID'];
-	    }
+            
+            // 地上波の時は ServiceID を 10進数に変換する（変換時に頭の 0x は不要なので除去）
+            // BS CS の時はそのまま流す
+            // 切り替え基準の sid は衛星で存在する実況チャンネルが AT-X(333)までなのでそれを目安に設定
+            if　(intval($channel_sid) > 333) {
+                $jikkyo_sid = hexdec(mb_substr($channel_record['ServiceID'], 2));
+            } else {
+                $jikkyo_sid = $channel_record['ServiceID'];
+            }
 
-        // チャンネルが一致したら、かつ実況チャンネルが存在するとき
-        if ($jikkyo_sid == $channel_sid and ($channel_record['JikkyoID']) != '-1') {
-            return 'jk'.($channel_record['JikkyoID']);
-            break;
+            // チャンネルが一致したら、かつ実況チャンネル (JikkyoIDが -1 でない) が存在するとき
+            if ($jikkyo_sid == $channel_sid and ($channel_record['JikkyoID']) != '-1') {
+                return 'jk'.($channel_record['JikkyoID']);
+            }
         }
-	    }
-            // 一致するチャンネルがない
-            return null;
-        }
+        
+        // 一致するチャンネルがない
+        return null;
+    }
 
 
     /**

--- a/modules/Models/Jikkyo.php
+++ b/modules/Models/Jikkyo.php
@@ -125,39 +125,29 @@ class Jikkyo {
      * @param string $channel_name チャンネル名（放送局名）
      * @return ?string そのチャンネルの実況 ID
      */
-    public function getNicoJikkyoID(string $channel_name): ?string {
+    public function getNicoJikkyoID(string $channel_sid): ?string {
 
         // jikkyo_channels.json を読み込み
         $channel_table = json_decode(file_get_contents($this->jikkyo_channels_file), true);
 
         // 配列を回す
         foreach ($channel_table as $channel_record) {
+	
+	    if(intval($channel_sid) > 333){ // 地上波の時
+	        $jikkyo_sid = hexdec(mb_substr($channel_record['ServiceID'],2));
+	    }else { // 地上波以外
+	        $jikkyo_sid = $channel_record['ServiceID'];
+	    }
 
-            // 抽出したチャンネル名
-            $channel_field = $channel_record['Channel'];
-            
-            // 正規表現用の文字をエスケープ
-            $channel_field_escape = str_replace('/', '\/', preg_quote($channel_field));
-
-            // 正規表現パターン
-            mb_regex_encoding('UTF-8');
-            $match = '/^'.str_replace('NHK総合', 'NHK総合[0-9]?', str_replace('NHKEテレ', 'NHKEテレ[0-9]?', $channel_field_escape)).'[0-9]?$/u';
-
-            // チャンネル名がいずれかのパターンに一致したら
-            if ($channel_name === $channel_field or preg_match($match, $channel_name)) {
-
-                // 実況 ID を返す
-                if (intval($channel_record['JikkyoID']) > 0) {
-                    return 'jk'.$channel_record['JikkyoID'];
-                } else {
-                    return null;
-                }
-            }
+        // チャンネルが一致したら、かつ実況チャンネルが存在するとき
+        if ($jikkyo_sid == $channel_sid and ($channel_record['JikkyoID']) != '-1') {
+            return 'jk'.($channel_record['JikkyoID']);
+            break;
         }
-
-        // チャンネル名が一致しなかった
-        return null;
-    }
+	    }
+            // 一致するチャンネルがない
+            return null;
+        }
 
 
     /**


### PR DESCRIPTION
実況チャンネルをサービスidで判断して選択するように変更してみました。
からくりは、現状のと同じで配列まわしてサービスidが同じ場合は実況idを返すしくみ。
地上波の時だけチャンネルデータが16進数なので、内部用と同じ10進数に変換して検証させてます。