### PR TITLE
設定ファイルのロックなど

### DIFF
--- a/htdocs/api/chromecast.php
+++ b/htdocs/api/chromecast.php
@@ -12,8 +12,8 @@
 	$stream = getStreamNumber($_SERVER['REQUEST_URI']);
 
 	// 設定ファイル読み込み
-	$ini = json_decode(file_get_contents($inifile), true);
-	$cast = json_decode(file_get_contents($castfile), true);
+	$ini = json_decode(file_get_contents_lock_sh($inifile), true);
+	$cast = json_decode(file_get_contents_lock_sh($castfile), true);
 
 	$json = array(
 		'api' => 'chromecast'
@@ -96,7 +96,7 @@
 				}
 
 				// 取得できなかった時用に結果を保存しておく
-				file_put_contents($scanfile, json_encode($scandata, JSON_UNESCAPED_UNICODE|JSON_PRETTY_PRINT));
+				file_put_contents($scanfile, json_encode($scandata, JSON_UNESCAPED_UNICODE|JSON_PRETTY_PRINT), LOCK_EX);
 			}
 
 		}
@@ -111,8 +111,9 @@
 		$scanflg = false;
 
 		// 保存されてあれば読み込む
-		if (file_exists($scanfile)){
-			$scandata = json_decode(file_get_contents($scanfile), true);
+		$scandata = file_get_contents_lock_sh($scanfile);
+		if ($scandata !== false) {
+			$scandata = json_decode($scandata, true);
 		} else {
 			$scandata = array();
 		}
@@ -156,7 +157,7 @@
 			
 			// 0.5秒ごとに読み込み
 			usleep(500000);
-			$cast_ = json_decode(file_get_contents($castfile), true);
+			$cast_ = json_decode(file_get_contents_lock_sh($castfile), true);
 			// 再生が開始されたらbreak
 			if ($cast_['status'] == 'play'){
 				$cast['status'] = 'play';
@@ -178,6 +179,6 @@
 
 	// 出力
 	header('content-type: application/json; charset=utf-8');
-	file_put_contents($castfile, json_encode($cast, JSON_UNESCAPED_UNICODE|JSON_PRETTY_PRINT));
+	file_put_contents($castfile, json_encode($cast, JSON_UNESCAPED_UNICODE|JSON_PRETTY_PRINT), LOCK_EX);
 	echo json_encode($json, JSON_UNESCAPED_UNICODE|JSON_PRETTY_PRINT);
 

--- a/htdocs/api/epginfo.php
+++ b/htdocs/api/epginfo.php
@@ -20,7 +20,7 @@
 	$stream = getStreamNumber($_SERVER['REQUEST_URI']);
 
 	// 設定ファイル読み込み
-	$ini = json_decode(file_get_contents($inifile), true);
+	$ini = json_decode(file_get_contents_lock_sh($inifile), true);
 
 	// コンテキストを読み込む
 	libxml_set_streams_context($ssl_context);

--- a/htdocs/api/listupdate.php
+++ b/htdocs/api/listupdate.php
@@ -9,17 +9,18 @@
 	set_time_limit(0);
 
 	// jsonからデコードして代入
-	if (file_exists($infofile)){
-		$TSfile = json_decode(file_get_contents($infofile), true);
+	$TSfile = file_get_contents_lock_sh($infofile);
+	if ($TSfile !== false) {
+		$TSfile = json_decode($TSfile, true);
 	} else {
-		$TSfile = array();
+		$TSfile = array('data' => array());
 	}
 
 	// リストリセット
 	if (isset($_GET['list_reset'])){
 
-		// jsonを削除
-		@unlink($infofile);
+		// jsonを空にする
+		file_put_contents($infofile, json_encode(array('data' => array()), JSON_UNESCAPED_UNICODE|JSON_PRETTY_PRINT), LOCK_EX);
 		// ロックファイルを削除
 		@unlink($infofile.'.lock');
 
@@ -37,8 +38,8 @@
 	// 再生履歴を削除
 	if (isset($_GET['history_reset'])){
 
-		// jsonを削除
-		@unlink($historyfile);
+		// jsonを空にする
+		file_put_contents($historyfile, json_encode(array('data' => array()), JSON_UNESCAPED_UNICODE|JSON_PRETTY_PRINT), LOCK_EX);
 
 		$json = array(
 			'api' => 'listupdate',
@@ -371,7 +372,7 @@
 		}
 
 		// ファイルに保存
-		file_put_contents($infofile, json_encode($TSfile, JSON_UNESCAPED_UNICODE|JSON_PRETTY_PRINT));
+		file_put_contents($infofile, json_encode($TSfile, JSON_UNESCAPED_UNICODE|JSON_PRETTY_PRINT), LOCK_EX);
 
 		// lockファイルを削除
 		@unlink($infofile.'.lock');

--- a/htdocs/api/status.php
+++ b/htdocs/api/status.php
@@ -8,7 +8,7 @@
 	$stream = getStreamNumber($_SERVER['REQUEST_URI']);
 
 	// 設定ファイル読み込み
-	$ini = json_decode(file_get_contents($inifile), true);
+	$ini = json_decode(file_get_contents_lock_sh($inifile), true);
 
 	// セッションのファイル数を返す関数
 	function getActiveCount() {

--- a/htdocs/api/stream.php
+++ b/htdocs/api/stream.php
@@ -8,7 +8,7 @@
 	$stream = getStreamNumber($_SERVER['REQUEST_URI']);
 
 	// 設定ファイル読み込み
-	$ini = json_decode(file_get_contents($inifile), true);
+	$ini = json_decode(file_get_contents_lock_sh($inifile), true);
 
 	// 動画を出力する関数
 	// https://blog.logicky.com/2019/05/29/151209?utm_source=feed

--- a/htdocs/files/error/400.php
+++ b/htdocs/files/error/400.php
@@ -1,5 +1,5 @@
 <?php
-http_response_code(500);
+http_response_code(400);
 ?>
 <!Doctype html>
 <html>

--- a/htdocs/files/error/403.php
+++ b/htdocs/files/error/403.php
@@ -1,10 +1,14 @@
 <?php
 
 // サムネイルが403ならデフォルト画像を返すようにする
-if (strpos($_SERVER['REQUEST_URI'], '/files/info/') !== false){
-  http_response_code(200);
-	header('Content-Type: image/jpg');
-	readfile('../thumb_default.jpg');	
+if (strpos($_SERVER['REQUEST_URI'], '/files/thumb/') !== false){
+	$name = '../thumb_default.jpg';
+	if (is_file($name)) {
+		http_response_code(200);
+		header('Content-Type: image/jpeg');
+		readfile($name);
+		exit;
+	}
 }
 
 // 通常のなら403ページを表示

--- a/htdocs/files/error/404.php
+++ b/htdocs/files/error/404.php
@@ -2,9 +2,13 @@
 
 // サムネイルが404ならデフォルト画像を返すようにする
 if (strpos($_SERVER['REQUEST_URI'], '/files/thumb/') !== false){
-  http_response_code(200);
-	header('Content-Type: image/jpg');
-	readfile('../thumb_default.jpg');	
+	$name = '../thumb_default.jpg';
+	if (is_file($name)) {
+		http_response_code(200);
+		header('Content-Type: image/jpeg');
+		readfile($name);
+		exit;
+	}
 }
 
 // 通常のなら404ページを表示

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -31,7 +31,7 @@
 	}
 
 	// 設定ファイル読み込み
-	$ini = json_decode(file_get_contents($inifile), true);
+	$ini = json_decode(file_get_contents_lock_sh($inifile), true);
 
 	// basic 認証設定を実行
 	basicAuth($basicauth, $basicauth_user, $basicauth_password);

--- a/htdocs/watch.php
+++ b/htdocs/watch.php
@@ -214,10 +214,10 @@
 
 	// ファイルを四階層まで検索する
 	// MP4・MKVファイルも検索する
-	$search = array_merge(glob($TSfile_dir.'/*{.ts,.mts,.m2t,.m2ts,.mp4,.mkv}', GLOB_BRACE),
-						  glob($TSfile_dir.'/*/*{.ts,.mts,.m2t,.m2ts,.mp4,.mkv}', GLOB_BRACE),
-						  glob($TSfile_dir.'/*/*/*{.ts,.mts,.m2t,.m2ts,.mp4,.mkv}', GLOB_BRACE),
-						  glob($TSfile_dir.'/*/*/*/*{.ts,.mts,.m2t,.m2ts,.mp4,.mkv}', GLOB_BRACE));
+	$search = @scandir_and_match_files($TSfile_dir, '/.\\.(ts|mts|m2t|m2ts|mp4|mkv)$/i', 4);
+	if ($search === false) {
+		$search = array();
+	}
   
 	if (file_exists($infofile)){
 		$TSfile = json_decode(file_get_contents($infofile), true);

--- a/htdocs/watch.php
+++ b/htdocs/watch.php
@@ -219,10 +219,11 @@
 		$search = array();
 	}
   
-	if (file_exists($infofile)){
-		$TSfile = json_decode(file_get_contents($infofile), true);
+	$TSfile = file_get_contents_lock_sh($infofile);
+	if ($TSfile !== false) {
+		$TSfile = json_decode($TSfile, true);
 	} else {
-		$TSfile['data'] = array();
+		$TSfile = array('data' => array());
 	}
 
 	// ファイルリストに記録されたファイル数と異なる場合

--- a/modules/Cast/cast.php
+++ b/modules/Cast/cast.php
@@ -7,7 +7,8 @@
 // your Chromecast through your firewall. Preferably with port forwarding
 // from a different port address.
 
-@require_once (str_replace('Cast', '', dirname(__FILE__)).'require.php');
+require_once (preg_replace('#[^/\\\\]*$#', '', __DIR__).'require.php');
+require_once (preg_replace('#[^/\\\\]*$#', '', __DIR__).'module.php');
 require_once ('Chromecast.php');
 
 // 引数確認

--- a/modules/Cast/cast.php
+++ b/modules/Cast/cast.php
@@ -40,9 +40,9 @@ $cc->DMP->SetVolume(0.7);
 $cc->DMP->UnMute();
 
 // 通知
-$cast = json_decode(file_get_contents(dirname(__FILE__).'/cast.json'), true);
+$cast = json_decode(file_get_contents_lock_sh(dirname(__FILE__).'/cast.json'), true);
 $cast['status'] = 'play';
-file_put_contents(dirname(__FILE__).'/cast.json', json_encode($cast, JSON_UNESCAPED_UNICODE|JSON_PRETTY_PRINT));
+file_put_contents(dirname(__FILE__).'/cast.json', json_encode($cast, JSON_UNESCAPED_UNICODE|JSON_PRETTY_PRINT), LOCK_EX);
 
 echo '  Chromecast Play.'."\n\n";
 
@@ -55,7 +55,7 @@ while(true){
 	} else {
 		$cmd_old = '';
 	}
-	$cmd = json_decode(file_get_contents(dirname(__FILE__).'/cast.json'), true);
+	$cmd = json_decode(file_get_contents_lock_sh(dirname(__FILE__).'/cast.json'), true);
 
 	if ($cmd != $cmd_old){
 

--- a/modules/Controllers/JikkyoController.php
+++ b/modules/Controllers/JikkyoController.php
@@ -17,7 +17,7 @@ class JikkyoController {
         $stream = getStreamNumber($_SERVER['REQUEST_URI']);
 
         // 設定ファイル読み込み
-        $settings = json_decode(file_get_contents($inifile), true);
+        $settings = json_decode(file_get_contents_lock_sh($inifile), true);
 
         // ストリームが存在する
         if (isset($settings[$stream])) {

--- a/modules/Models/Jikkyo.php
+++ b/modules/Models/Jikkyo.php
@@ -599,7 +599,7 @@ class Jikkyo {
             }
 
             // jikkyo_ikioi.json に保存
-            file_put_contents($jikkyo_ikioi_file, json_encode($jikkyo_ikioi, JSON_UNESCAPED_UNICODE|JSON_PRETTY_PRINT));
+            file_put_contents($jikkyo_ikioi_file, json_encode($jikkyo_ikioi, JSON_UNESCAPED_UNICODE|JSON_PRETTY_PRINT), LOCK_EX);
         };
 
         // jikkyo_ikioi.json が存在しない or 更新されてから 20 秒以上経っている
@@ -612,7 +612,7 @@ class Jikkyo {
         }
 
         // jikkyo_ikioi.json から実況勢いを取得
-        $jikkyo_ikioi = json_decode(file_get_contents($this->jikkyo_ikioi_file), true);
+        $jikkyo_ikioi = json_decode(file_get_contents_lock_sh($this->jikkyo_ikioi_file), true);
 
         // 指定された実況チャンネルのものを返す
         if (isset($jikkyo_ikioi[$nicojikkyo_id])) {

--- a/modules/header.php
+++ b/modules/header.php
@@ -16,7 +16,7 @@
 	$stream = getStreamNumber($_SERVER['REQUEST_URI']);
 
 	// iniファイル読み込み
-	$ini = json_decode(file_get_contents($inifile), true);
+	$ini = json_decode(file_get_contents_lock_sh($inifile), true);
 
 	$backtrace = debug_backtrace();
 

--- a/modules/module.php
+++ b/modules/module.php
@@ -12,6 +12,34 @@
 		}
 	}
 
+	// ディレクトリを (再帰的に) スキャンして正規表現にマッチするファイルを返す
+	function scandir_and_match_files($dir, $pattern = null, $depth = 1) {
+		$dir = realpath($dir);
+		if ($dir !== false && ($dh = opendir($dir))) {
+			$ret = array();
+			while (($file = readdir($dh)) !== false) {
+				if ($file !== '.' && $file !== '..') {
+					$path = $dir.DIRECTORY_SEPARATOR.$file;
+					if (!is_dir($path)) {
+						if (!isset($pattern) || preg_match($pattern, $file)) {
+							$ret[] = $file;
+						}
+					} elseif ($depth > 1) {
+						$sub = scandir_and_match_files($path, $pattern, $depth - 1);
+						if ($sub !== false) {
+							foreach ($sub as $v) {
+								$ret[] = $file.'/'.$v;
+							}
+						}
+					}
+				}
+			}
+			closedir($dh);
+			return $ret;
+		}
+		return false;
+	}
+
 	// Windows用コマンド実行関数
 	// proc_open を用いることで非同期でも実行できるようにする
 	function win_exec($cmd, $log = null, $errorlog = null){

--- a/modules/stream.php
+++ b/modules/stream.php
@@ -19,7 +19,7 @@
 			= initBonChannel($BonDriver_dir);
 
 		// 設定読み込み
-		$ini = json_decode(file_get_contents($inifile), true);
+		$ini = json_decode(file_get_contents_lock_sh($inifile), true);
 
 		// コマンドラインからのストリーム開始・停止はおまけ機能です
 		// ファイル再生機能は今の所ついていません
@@ -125,7 +125,7 @@
 			}
 
 			// ファイル書き込み
-			file_put_contents($inifile, json_encode($ini, JSON_UNESCAPED_UNICODE|JSON_PRETTY_PRINT));
+			file_put_contents($inifile, json_encode($ini, JSON_UNESCAPED_UNICODE|JSON_PRETTY_PRINT), LOCK_EX);
 
 			echo ' ---------------------------------------------------'."\n";
 			echo '   Stream started.'."\n";
@@ -173,7 +173,7 @@
 			}
 
 			// ファイル書き込み
-			file_put_contents($inifile, json_encode($ini, JSON_UNESCAPED_UNICODE|JSON_PRETTY_PRINT));
+			file_put_contents($inifile, json_encode($ini, JSON_UNESCAPED_UNICODE|JSON_PRETTY_PRINT), LOCK_EX);
 
 			echo ' ---------------------------------------------------'."\n";
 			echo '   Stream stoped.'."\n";
@@ -196,7 +196,7 @@
 		global $inifile, $udp_port, $ffmpeg_path, $qsvencc_path, $nvencc_path, $vceencc_path, $tstask_path, $tstaskcentreex_path, $segment_folder, $hlslive_time, $hlslive_list, $base_dir, $encoder_log, $encoder_window, $TSTask_window;
 
 		// 設定ファイル読み込み
-		$settings = json_decode(file_get_contents($inifile), true);
+		$settings = json_decode(file_get_contents_lock_sh($inifile), true);
 
 		// 以前の state が ONAir (TSTask を再利用できる)
 		if ($settings[strval($stream)]['state'] === 'ONAir') {
@@ -859,7 +859,7 @@
 			$stream_port = $udp_port + intval($stream);
 
 			// 録画ファイルのファイルパス
-			$filepath = @json_decode(file_get_contents($inifile), true)[$stream]['filepath'];
+			$filepath = @json_decode(file_get_contents_lock_sh($inifile), true)[$stream]['filepath'];
 			if ($filepath === null) $filepath = '';
 
 			// 現在のプロセスのコマンドライン引数とプロセスIDを取得する


### PR DESCRIPTION
4b8115943b0c8e59beffa7131b8960899bfe96cf はおもに「録画番組」ページの表示速度の改善です。
録画フォルダに数百個単位でファイル放置してないと共感得られないかも…ってのはありますが、`glob()` vs `readdir()` で6～10倍パフォーマンスが変わってきます。
f361cf7d98dc3ba4164f9df011c4a52bfc136141 は「なにもしてないけどファイルが壊れた」系のエラーを避けるものです。
